### PR TITLE
CSAF Catchup for kernel

### DIFF
--- a/csaf/vex/cve/2022/cve-2022-4378.json
+++ b/csaf/vex/cve/2022/cve-2022-4378.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2022-4378",
       "initial_release_date": "2024-08-14T20:12:27Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-12T20:24:20Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2024-08-14T20:12:27Z",
@@ -42,6 +42,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:20Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -71,28 +76,6 @@
                         "product": {
                           "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
                           "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686"
                         }
                       }
                     ]
@@ -588,6 +571,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -607,8 +848,6 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
-          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -667,7 +906,37 @@
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -676,8 +945,6 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -736,7 +1003,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -758,8 +1055,6 @@
           },
           "products": [
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -818,7 +1113,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -828,8 +1153,6 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -888,7 +1211,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2022/cve-2022-45886.json
+++ b/csaf/vex/cve/2022/cve-2022-45886.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2022-45886",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-12T20:24:21Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:21Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -472,28 +477,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -745,6 +728,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -812,8 +1053,6 @@
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -843,7 +1082,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -900,8 +1169,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -931,7 +1198,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1001,8 +1298,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -1032,7 +1327,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1090,8 +1415,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -1121,7 +1444,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2022/cve-2022-45919.json
+++ b/csaf/vex/cve/2022/cve-2022-45919.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2022-45919",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-12T20:24:21Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:21Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -472,28 +477,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -745,6 +728,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -812,8 +1053,6 @@
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -843,7 +1082,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -900,8 +1169,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -931,7 +1198,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1001,8 +1298,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -1032,7 +1327,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1090,8 +1415,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -1121,7 +1444,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-0266.json
+++ b/csaf/vex/cve/2023/cve-2023-0266.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-0266",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-12T20:24:21Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:21Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -477,28 +482,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -750,6 +733,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -817,8 +1058,6 @@
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -848,7 +1087,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -905,8 +1174,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -936,7 +1203,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1006,8 +1303,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -1037,7 +1332,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1100,8 +1425,6 @@
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
@@ -1131,7 +1454,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-0386.json
+++ b/csaf/vex/cve/2023/cve-2023-0386.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-0386",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T21:45:34Z",
+      "current_release_date": "2025-09-12T20:24:21Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-09-05T21:45:34Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:21Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -723,6 +728,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -819,7 +1082,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -905,7 +1198,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1004,7 +1327,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1091,7 +1444,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-1281.json
+++ b/csaf/vex/cve/2023/cve-2023-1281.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-1281",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T21:45:34Z",
+      "current_release_date": "2025-09-12T20:24:21Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-09-05T21:45:34Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:21Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -920,6 +925,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1037,7 +1300,37 @@
           "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
           "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
           "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
-          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch"
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -1144,7 +1437,37 @@
             "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
-            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch"
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1264,7 +1587,37 @@
             "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
-            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch"
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1372,7 +1725,37 @@
             "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
-            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch"
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-1829.json
+++ b/csaf/vex/cve/2023/cve-2023-1829.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-1829",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T21:45:34Z",
+      "current_release_date": "2025-09-12T20:24:21Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-09-05T21:45:34Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:21Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -920,6 +925,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1037,7 +1300,37 @@
           "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
           "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
           "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
-          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch"
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -1144,7 +1437,37 @@
             "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
-            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch"
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1264,7 +1587,37 @@
             "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
-            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch"
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1372,7 +1725,37 @@
             "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
-            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch"
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-2124.json
+++ b/csaf/vex/cve/2023/cve-2023-2124.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-2124",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T21:45:35Z",
+      "current_release_date": "2025-09-12T20:24:22Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-09-05T21:45:35Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:22Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -723,6 +728,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -819,7 +1082,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -905,7 +1198,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1004,7 +1327,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1091,7 +1444,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-2235.json
+++ b/csaf/vex/cve/2023/cve-2023-2235.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2023-2235",
       "initial_release_date": "2025-09-05T21:45:36Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:22Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2025-09-12T20:24:22Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -556,6 +561,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -633,7 +896,37 @@
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -700,7 +993,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -780,7 +1103,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -848,7 +1201,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-28466.json
+++ b/csaf/vex/cve/2023/cve-2023-28466.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-28466",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T21:45:35Z",
+      "current_release_date": "2025-09-12T20:24:22Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-09-05T21:45:35Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:22Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -723,6 +728,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -819,7 +1082,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -905,7 +1198,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1004,7 +1327,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1091,7 +1444,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3090.json
+++ b/csaf/vex/cve/2023/cve-2023-3090.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2023-3090",
       "initial_release_date": "2025-09-05T21:45:36Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:22Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2025-09-12T20:24:22Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -556,6 +561,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -633,7 +896,37 @@
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -700,7 +993,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -780,7 +1103,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -848,7 +1201,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-35001.json
+++ b/csaf/vex/cve/2023/cve-2023-35001.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2023-35001",
       "initial_release_date": "2025-09-05T21:45:36Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:22Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2025-09-12T20:24:22Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -556,6 +561,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -633,7 +896,37 @@
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -700,7 +993,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -780,7 +1103,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -848,7 +1201,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-35788.json
+++ b/csaf/vex/cve/2023/cve-2023-35788.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-35788",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T21:45:35Z",
+      "current_release_date": "2025-09-12T20:24:23Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-09-05T21:45:35Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:23Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -723,6 +728,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -819,7 +1082,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -905,7 +1198,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1004,7 +1327,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1091,7 +1444,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3609.json
+++ b/csaf/vex/cve/2023/cve-2023-3609.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3609",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T21:45:35Z",
+      "current_release_date": "2025-09-12T20:24:23Z",
       "status": "final",
-      "version": "7",
+      "version": "8",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -62,6 +62,11 @@
         {
           "date": "2025-09-05T21:45:35Z",
           "number": "7",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:23Z",
+          "number": "8",
           "summary": "Updated version"
         }
       ]
@@ -2398,6 +2403,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2691,7 +2954,37 @@
           "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -2974,7 +3267,37 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -3270,7 +3593,37 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -3554,7 +3907,37 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3776.json
+++ b/csaf/vex/cve/2023/cve-2023-3776.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3776",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:23Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:23Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -723,6 +728,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -819,7 +1082,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -905,7 +1198,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1004,7 +1327,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -1091,7 +1444,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3812.json
+++ b/csaf/vex/cve/2023/cve-2023-3812.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3812",
       "initial_release_date": "2025-05-19T12:13:39Z",
-      "current_release_date": "2025-09-05T22:05:42Z",
+      "current_release_date": "2025-09-12T20:24:23Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2025-05-19T12:13:39Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-09-05T22:05:42Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:23Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -2024,6 +2029,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2273,7 +2536,37 @@
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
-          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -2512,7 +2805,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -2764,7 +3087,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -3004,7 +3357,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-4004.json
+++ b/csaf/vex/cve/2023/cve-2023-4004.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2023-4004",
       "initial_release_date": "2025-09-05T21:45:36Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:23Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2025-09-12T20:24:23Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -556,6 +561,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -633,7 +896,37 @@
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -700,7 +993,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -780,7 +1103,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -848,7 +1201,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-4128.json
+++ b/csaf/vex/cve/2023/cve-2023-4128.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2023-4128",
       "initial_release_date": "2025-09-05T21:45:36Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:23Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2025-09-12T20:24:23Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -556,6 +561,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -633,7 +896,37 @@
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
           "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -700,7 +993,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -780,7 +1103,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -848,7 +1201,37 @@
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
             "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
-            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-4206.json
+++ b/csaf/vex/cve/2023/cve-2023-4206.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-4206",
       "initial_release_date": "2025-04-24T03:04:31Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:24Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2025-04-24T03:04:31Z",
@@ -57,6 +57,11 @@
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "6",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:24Z",
+          "number": "7",
           "summary": "Updated version"
         }
       ]
@@ -1747,6 +1752,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1963,7 +2226,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -2169,7 +2462,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -2388,7 +2711,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -2595,7 +2948,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-4207.json
+++ b/csaf/vex/cve/2023/cve-2023-4207.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-4207",
       "initial_release_date": "2025-04-24T03:04:31Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:24Z",
       "status": "final",
-      "version": "8",
+      "version": "9",
       "revision_history": [
         {
           "date": "2025-04-24T03:04:31Z",
@@ -67,6 +67,11 @@
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "8",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:24Z",
+          "number": "9",
           "summary": "Updated version"
         }
       ]
@@ -2755,6 +2760,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3092,7 +3355,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -3419,7 +3712,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -3759,7 +4082,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -4087,7 +4440,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-4208.json
+++ b/csaf/vex/cve/2023/cve-2023-4208.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-4208",
       "initial_release_date": "2025-04-24T03:04:31Z",
-      "current_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-12T20:24:24Z",
       "status": "final",
-      "version": "8",
+      "version": "9",
       "revision_history": [
         {
           "date": "2025-04-24T03:04:31Z",
@@ -67,6 +67,11 @@
         {
           "date": "2025-09-05T21:45:36Z",
           "number": "8",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:24Z",
+          "number": "9",
           "summary": "Updated version"
         }
       ]
@@ -2755,6 +2760,264 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3092,7 +3355,37 @@
           "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -3419,7 +3712,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -3759,7 +4082,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -4087,7 +4440,37 @@
             "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
-            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-44466.json
+++ b/csaf/vex/cve/2023/cve-2023-44466.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-44466",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-12T20:01:17Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -58,6 +58,11 @@
           "date": "2025-06-04T20:19:16Z",
           "number": "6",
           "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:01:17Z",
+          "number": "7",
+          "summary": "Updated version"
         }
       ]
     }
@@ -86,6 +91,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -236,6 +249,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
                         }
                       }
                     ]
@@ -402,7 +899,67 @@
           "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
         ]
       },
       "remediations": [
@@ -428,7 +985,67 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
           ]
         }
       ],
@@ -467,7 +1084,67 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
           ]
         }
       ],
@@ -494,7 +1171,67 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-51042.json
+++ b/csaf/vex/cve/2023/cve-2023-51042.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-51042",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T22:05:42Z",
+      "current_release_date": "2025-09-12T20:24:24Z",
       "status": "final",
-      "version": "8",
+      "version": "9",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -67,6 +67,11 @@
         {
           "date": "2025-09-05T22:05:42Z",
           "number": "8",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:24Z",
+          "number": "9",
           "summary": "Updated version"
         }
       ]
@@ -975,6 +980,238 @@
                           "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
                           "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
                       }
                     ]
                   },
@@ -988,6 +1225,14 @@
                         "product": {
                           "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
                           "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
                         }
                       }
                     ]
@@ -2566,7 +2811,37 @@
           "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -2853,7 +3128,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -3153,7 +3458,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -3441,7 +3776,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",

--- a/csaf/vex/cve/2023/cve-2023-6546.json
+++ b/csaf/vex/cve/2023/cve-2023-6546.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-6546",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T22:05:43Z",
+      "current_release_date": "2025-09-12T20:24:24Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -57,6 +57,11 @@
         {
           "date": "2025-09-05T22:05:43Z",
           "number": "6",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:24Z",
+          "number": "7",
           "summary": "Updated version"
         }
       ]
@@ -965,6 +970,238 @@
                           "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
                           "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
                       }
                     ]
                   },
@@ -978,6 +1215,14 @@
                         "product": {
                           "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
                           "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
                         }
                       }
                     ]
@@ -1618,7 +1863,37 @@
           "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -1793,7 +2068,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -1981,7 +2286,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -2157,7 +2492,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",

--- a/csaf/vex/cve/2023/cve-2023-6817.json
+++ b/csaf/vex/cve/2023/cve-2023-6817.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-6817",
       "initial_release_date": "2025-03-11T17:28:53Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-12T21:03:07Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2025-03-11T17:28:53Z",
@@ -57,6 +57,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "6",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T21:03:07Z",
+          "number": "7",
           "summary": "Updated version"
         }
       ]
@@ -2129,6 +2134,342 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "FIPS Compliant for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.src",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.src",
+                          "product_id": "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+                          "product_id": "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+                          "product_id": "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:rtla-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:rtla-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:rtla-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-tools-libs-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-tools-libs-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-tools-libs-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:python3-perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:python3-perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:python3-perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-tools-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-tools-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-tools-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-tools-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-tools-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-tools-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:python3-perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:python3-perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:python3-perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-ipaclones-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-ipaclones-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-ipaclones-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-selftests-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-selftests-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-selftests-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-cross-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-cross-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-cross-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debuginfo-common-x86_64-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debuginfo-common-x86_64-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debuginfo-common-x86_64-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                        "product": {
+                          "name": "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+                          "product_id": "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2389,7 +2730,46 @@
           "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64"
+          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.src",
+          "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+          "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+          "fips-9.2-compliant:kernel-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:rtla-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-tools-libs-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:python3-perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-tools-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-tools-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:python3-perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-ipaclones-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-selftests-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-cross-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debuginfo-common-x86_64-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+          "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
         ]
       },
       "remediations": [
@@ -2639,7 +3019,46 @@
             "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64"
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.src",
+            "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+            "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+            "fips-9.2-compliant:kernel-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:rtla-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-libs-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:python3-perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:python3-perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-ipaclones-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-selftests-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-cross-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debuginfo-common-x86_64-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
           ]
         }
       ],
@@ -2902,7 +3321,46 @@
             "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64"
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.src",
+            "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+            "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+            "fips-9.2-compliant:kernel-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:rtla-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-libs-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:python3-perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:python3-perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-ipaclones-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-selftests-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-cross-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debuginfo-common-x86_64-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
           ]
         }
       ],
@@ -3153,7 +3611,46 @@
             "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64"
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.src",
+            "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+            "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.noarch",
+            "fips-9.2-compliant:kernel-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:rtla-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-libs-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:python3-perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-partner-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-tools-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-extra-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:python3-perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-ipaclones-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:perf-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-selftests-internal-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:perf-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-cross-headers-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-devel-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debuginfo-common-x86_64-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-modules-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64",
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.9.1.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-6931.json
+++ b/csaf/vex/cve/2023/cve-2023-6931.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-6931",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-05T22:05:43Z",
+      "current_release_date": "2025-09-12T20:24:25Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -57,6 +57,11 @@
         {
           "date": "2025-09-05T22:05:43Z",
           "number": "6",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:25Z",
+          "number": "7",
           "summary": "Updated version"
         }
       ]
@@ -965,6 +970,238 @@
                           "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
                           "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
                       }
                     ]
                   },
@@ -978,6 +1215,14 @@
                         "product": {
                           "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
                           "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
                         }
                       }
                     ]
@@ -1618,7 +1863,37 @@
           "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -1793,7 +2068,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -1981,7 +2286,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
@@ -2157,7 +2492,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",

--- a/csaf/vex/cve/2023/cve-2023-6932.json
+++ b/csaf/vex/cve/2023/cve-2023-6932.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-6932",
       "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2025-06-11T18:37:21Z",
+      "current_release_date": "2025-09-12T20:36:09Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-05T13:59:34Z",
@@ -53,6 +53,11 @@
           "date": "2025-06-11T18:37:21Z",
           "number": "5",
           "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:36:09Z",
+          "number": "6",
+          "summary": "Updated version"
         }
       ]
     }
@@ -69,7 +74,7 @@
             "branches": [
               {
                 "category": "product_name",
-                "name": "CIQ FIPS Compliant for Rocky Linux 8",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
                 "branches": [
                   {
                     "category": "architecture",

--- a/csaf/vex/cve/2024/cve-2024-1086.json
+++ b/csaf/vex/cve/2024/cve-2024-1086.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-1086",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-12T20:24:25Z",
       "status": "final",
-      "version": "6",
+      "version": "8",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -58,6 +58,16 @@
           "date": "2025-06-04T20:19:16Z",
           "number": "6",
           "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T19:55:50Z",
+          "number": "7",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:24:25Z",
+          "number": "8",
+          "summary": "Updated version"
         }
       ]
     }
@@ -86,6 +96,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -236,6 +254,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
                         }
                       }
                     ]
@@ -473,6 +975,238 @@
                           "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
                           "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "product": {
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                        }
                       }
                     ]
                   },
@@ -486,6 +1220,14 @@
                         "product": {
                           "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
                           "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "product": {
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
                         }
                       }
                     ]
@@ -978,6 +1720,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -996,6 +1739,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1024,7 +1826,37 @@
           "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
           "fips-9:kernel-5.14.0-284.30.1.el9_2.ciq_fips.0.3.src",
           "fips-9:kernel-5.14.0-284.30.1.el9_2.ciq_fips.0.3.x86_64",
           "fips-9:kernel-core-5.14.0-284.30.1.el9_2.ciq_fips.0.3.x86_64",
@@ -1087,6 +1919,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1105,6 +1938,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1133,7 +2025,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "fips-9:kernel-5.14.0-284.30.1.el9_2.ciq_fips.0.3.src",
             "fips-9:kernel-5.14.0-284.30.1.el9_2.ciq_fips.0.3.x86_64",
             "fips-9:kernel-core-5.14.0-284.30.1.el9_2.ciq_fips.0.3.x86_64",
@@ -1209,6 +2131,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1227,6 +2150,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1255,7 +2237,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "fips-9:kernel-5.14.0-284.30.1.el9_2.ciq_fips.0.3.src",
             "fips-9:kernel-5.14.0-284.30.1.el9_2.ciq_fips.0.3.x86_64",
             "fips-9:kernel-core-5.14.0-284.30.1.el9_2.ciq_fips.0.3.x86_64",
@@ -1324,6 +2336,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1342,6 +2355,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1370,7 +2442,37 @@
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
             "fips-9:kernel-5.14.0-284.30.1.el9_2.ciq_fips.0.3.src",
             "fips-9:kernel-5.14.0-284.30.1.el9_2.ciq_fips.0.3.x86_64",
             "fips-9:kernel-core-5.14.0-284.30.1.el9_2.ciq_fips.0.3.x86_64",

--- a/csaf/vex/cve/2024/cve-2024-25742.json
+++ b/csaf/vex/cve/2024/cve-2024-25742.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-25742",
       "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2025-08-29T17:04:57Z",
+      "current_release_date": "2025-09-12T20:36:09Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-05T13:59:34Z",
@@ -53,6 +53,11 @@
           "date": "2025-08-29T17:04:57Z",
           "number": "5",
           "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-12T20:36:09Z",
+          "number": "6",
+          "summary": "Updated version"
         }
       ]
     }
@@ -69,7 +74,7 @@
             "branches": [
               {
                 "category": "product_name",
-                "name": "CIQ FIPS Compliant for Rocky Linux 8",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
                 "branches": [
                   {
                     "category": "architecture",
@@ -361,28 +366,6 @@
                         "product": {
                           "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.src",
                           "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
-                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
-                        "product": {
-                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
-                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686"
                         }
                       }
                     ]
@@ -929,8 +912,6 @@
           "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
           "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.src",
-          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
-          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.noarch",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.aarch64",
@@ -1030,8 +1011,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.src",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.aarch64",
@@ -1144,8 +1123,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.src",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.aarch64",
@@ -1246,8 +1223,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.src",
-            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
-            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.i686",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.noarch",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.aarch64",


### PR DESCRIPTION
There a hand full of lts8.6 lts9.2 that need to be published that have not yet been.  The biggest impact was fips-legacy-8.6 mostly everything before 425.13.1.0.30 kernel version.