### PR TITLE
[LTS 8.8] Add CVEs fixed prior to CSAF project

### DIFF
--- a/csaf/vex/cve/2023/cve-2023-4128.json
+++ b/csaf/vex/cve/2023/cve-2023-4128.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-4128",
       "initial_release_date": "2025-09-05T21:45:36Z",
-      "current_release_date": "2025-09-12T20:24:23Z",
+      "current_release_date": "2025-10-22T22:59:20Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2025-09-05T21:45:36Z",
@@ -37,6 +37,11 @@
         {
           "date": "2025-09-12T20:24:23Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-10-22T22:59:20Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -819,6 +824,538 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+                        "product": {
+                          "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+                          "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+                        "product": {
+                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+                        "product": {
+                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+                        "product": {
+                          "name": "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+                          "product_id": "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+                        "product": {
+                          "name": "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+                          "product_id": "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -926,7 +1463,69 @@
           "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
           "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
           "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+          "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+          "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
         ]
       },
       "remediations": [
@@ -1023,7 +1622,69 @@
             "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
           ]
         }
       ],
@@ -1133,7 +1794,69 @@
             "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
           ]
         }
       ],
@@ -1231,7 +1954,69 @@
             "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
             "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-1086.json
+++ b/csaf/vex/cve/2024/cve-2024-1086.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-1086",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-12T22:01:49Z",
+      "current_release_date": "2025-10-22T22:59:20Z",
       "status": "final",
-      "version": "9",
+      "version": "10",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -72,6 +72,11 @@
         {
           "date": "2025-09-12T22:01:49Z",
           "number": "9",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-10-22T22:59:20Z",
+          "number": "10",
           "summary": "Updated version"
         }
       ]
@@ -2472,6 +2477,538 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+                        "product": {
+                          "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+                          "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+                        "product": {
+                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+                        "product": {
+                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+                        "product": {
+                          "name": "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+                          "product_id": "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+                        "product": {
+                          "name": "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+                          "product_id": "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                        "product": {
+                          "name": "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+                          "product_id": "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                        "product": {
+                          "name": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+                          "product_id": "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2773,7 +3310,69 @@
           "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
-          "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64"
+          "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
+          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+          "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+          "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+          "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
         ]
       },
       "remediations": [
@@ -3064,7 +3663,69 @@
             "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
-            "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64"
+            "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
           ]
         }
       ],
@@ -3368,7 +4029,69 @@
             "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
-            "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64"
+            "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
           ]
         }
       ],
@@ -3665,7 +4388,69 @@
             "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
-            "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64"
+            "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
+            "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-common-aarch64-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.aarch64"
           ]
         }
       ]


### PR DESCRIPTION
These CVEs were completed prior to the CSAF project getting into full swing.  We know via release tagging in the kernel-src-tree which binaries they're associated.  We picked CSAF files if they had the same NVR (save some minor variation) to get the all the binary file names. If we had a release that does not seem to be represented in CSAF we picked the nearest one that existed and used those binary file names.