### PR TITLE
[LTS 8.6] Add CVEs fixed prior to CSAF project

### DIFF
--- a/csaf/vex/cve/2021/cve-2021-33631.json
+++ b/csaf/vex/cve/2021/cve-2021-33631.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2021-33631",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -81,6 +86,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
                         }
                       }
                     ]
@@ -231,6 +244,512 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
                         }
                       }
                     ]
@@ -1037,6 +1556,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1055,6 +1575,67 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
           "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1154,6 +1735,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1172,6 +1754,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1284,6 +1927,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1302,6 +1946,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1402,6 +2107,7 @@
           "details": "Moderate",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1420,6 +2126,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",

--- a/csaf/vex/cve/2022/cve-2022-0854.json
+++ b/csaf/vex/cve/2022/cve-2022-0854.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-0854",
+    "tracking": {
+      "id": "CVE-2022-0854",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-0854",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A memory leak flaw was found in the Linux kernel\u2019s DMA subsystem, in the way a user calls DMA_FROM_DEVICE. This flaw allows a local user to read random memory from the kernel space."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-1016.json
+++ b/csaf/vex/cve/2022/cve-2022-1016.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-1016",
+    "tracking": {
+      "id": "CVE-2022-1016",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-1016",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel in net/netfilter/nf_tables_core.c:nft_do_chain, which can cause a use-after-free. This issue needs to handle 'return' with proper preconditions, as it can lead to a kernel information leak problem caused by a local, unprivileged attacker."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-26373.json
+++ b/csaf/vex/cve/2022/cve-2022-26373.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-26373",
+    "tracking": {
+      "id": "CVE-2022-26373",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-26373",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in hw. In certain processors with Intel's Enhanced Indirect Branch Restricted Speculation (eIBRS) capabilities, soon after VM exit or IBPB command event, the linear address following the most recent near CALL instruction prior to a VM exit may be used as the Return Stack Buffer (RSB) prediction."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-3028.json
+++ b/csaf/vex/cve/2022/cve-2022-3028.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-3028",
+    "tracking": {
+      "id": "CVE-2022-3028",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-3028",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A race condition was found in the Linux kernel's IP framework for transforming packets (XFRM subsystem) when multiple calls to xfrm_probe_algs occurred simultaneously. This flaw could allow a local attacker to potentially trigger an out-of-bounds write or leak kernel heap memory by performing an out-of-bounds read and copying it into a socket."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.7,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-30594.json
+++ b/csaf/vex/cve/2022/cve-2022-30594.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-30594",
+    "tracking": {
+      "id": "CVE-2022-30594",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-30594",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel. The PTRACE_SEIZE code path allows attackers to bypass intended restrictions on setting the PT_SUSPEND_SECCOMP flag, possibly disabling seccomp."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-3567.json
+++ b/csaf/vex/cve/2022/cve-2022-3567.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-3567",
+    "tracking": {
+      "id": "CVE-2022-3567",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-3567",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A data race problem was found in sk->sk_prot in the network subsystem in ipv6 in the Linux kernel. This issue occurs while some functions access critical data, leading to a denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "ADJACENT_NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:A/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-3628.json
+++ b/csaf/vex/cve/2022/cve-2022-3628.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-3628",
+    "tracking": {
+      "id": "CVE-2022-3628",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-3628",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A buffer overflow flaw was found in the Linux kernel Broadcom Full MAC Wi-Fi driver. This issue occurs when a user connects to a malicious USB device. This can allow a local user to crash the system or escalate their privileges."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "PHYSICAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-41218.json
+++ b/csaf/vex/cve/2022/cve-2022-41218.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-41218",
+    "tracking": {
+      "id": "CVE-2022-41218",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-41218",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in the Linux kernel\u2019s dvb-core subsystem (DVB API used by Digital TV devices) in how a user physically removed a USB device (such as a DVB demultiplexer device) while running malicious code. This flaw allows a local user to crash or potentially escalate their privileges on the system."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-4129.json
+++ b/csaf/vex/cve/2022/cve-2022-4129.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-4129",
+    "tracking": {
+      "id": "CVE-2022-4129",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-4129",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel's Layer 2 Tunneling Protocol (L2TP). A missing lock when clearing sk_user_data can lead to a race condition and NULL pointer dereference. A local user could use this flaw to potentially crash the system causing a denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-43750.json
+++ b/csaf/vex/cve/2022/cve-2022-43750.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-43750",
+    "tracking": {
+      "id": "CVE-2022-43750",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-43750",
+      "notes": [
+        {
+          "category": "description",
+          "text": "An out-of-bounds memory write flaw in the Linux kernel\u2019s USB Monitor component was found in how a user with access to the /dev/usbmon can trigger it by an incorrect write to the memory of the usbmon. This flaw allows a local user to crash or potentially escalate their privileges on the system."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.7,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-47929.json
+++ b/csaf/vex/cve/2022/cve-2022-47929.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-47929",
+    "tracking": {
+      "id": "CVE-2022-47929",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-47929",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A NULL pointer dereference flaw was found in qdisc_graft in net/sched/sch_api.c in the Linux kernel. This issue may allow a local unprivileged user to trigger a denial of service if the alloc_workqueue function return is not validated in time of failure, resulting in a system crash or leaked internal kernel information."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.2,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-0394.json
+++ b/csaf/vex/cve/2023/cve-2023-0394.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-0394",
+    "tracking": {
+      "id": "CVE-2023-0394",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-0394",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A NULL pointer dereference flaw was found in rawv6_push_pending_frames in net/ipv6/raw.c in the network subcomponent in the Linux kernel. This flaw causes the system to crash."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "ADJACENT_NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-1073.json
+++ b/csaf/vex/cve/2023/cve-2023-1073.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-1073",
+    "tracking": {
+      "id": "CVE-2023-1073",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-1073",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A memory corruption flaw was found in the Linux kernel\u2019s human interface device (HID) subsystem in how a user inserts a malicious USB device. This flaw allows a local user to crash or potentially escalate their privileges on the system."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "PHYSICAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.6,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:P/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-1079.json
+++ b/csaf/vex/cve/2023/cve-2023-1079.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-1079",
+    "tracking": {
+      "id": "CVE-2023-1079",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-1079",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in asus_kbd_backlight_set in drivers/hid/hid-asus.c in the Linux Kernel. This issue could allow an attacker to crash the system when plugging in or disconnecting a malicious USB device, which may lead to a kernel information leak problem."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "PHYSICAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-1192.json
+++ b/csaf/vex/cve/2023/cve-2023-1192.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-1192",
+    "tracking": {
+      "id": "CVE-2023-1192",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-1192",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in smb2_is_status_io_timeout() in CIFS in the Linux Kernel. After CIFS transfers response data to a system call, there are still local variable points to the memory region, and if the system call frees it faster than CIFS uses it, CIFS will access a free memory region, leading to a denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Low",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-1195.json
+++ b/csaf/vex/cve/2023/cve-2023-1195.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-1195",
+    "tracking": {
+      "id": "CVE-2023-1195",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-1195",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in reconn_set_ipaddr_from_hostname in fs/cifs/connect.c in the Linux kernel. The issue occurs when it forgets to set the free pointer server->hostname to NULL, leading to an invalid pointer request."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-1382.json
+++ b/csaf/vex/cve/2023/cve-2023-1382.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-1382",
+    "tracking": {
+      "id": "CVE-2023-1382",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-1382",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A data race flaw was found in the Linux kernel, between where con is allocated and con->sock is set. This issue leads to a NULL pointer dereference when accessing con->sock->sk in net/tipc/topsrv.c in the tipc protocol in the Linux kernel."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-1855.json
+++ b/csaf/vex/cve/2023/cve-2023-1855.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-1855",
+    "tracking": {
+      "id": "CVE-2023-1855",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-1855",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in xgene_hwmon_remove in drivers/hwmon/xgene-hwmon.c in the Hardware Monitoring Linux Kernel driver (xgene-hwmon). This flaw could allow a local attacker to crash the system due to a race problem, possibly leading to a kernel information leak."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Low",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-1998.json
+++ b/csaf/vex/cve/2023/cve-2023-1998.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-1998",
+    "tracking": {
+      "id": "CVE-2023-1998",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-1998",
+      "notes": [
+        {
+          "category": "description",
+          "text": "It was found that the Linux Kernel still left the victim process exposed to attacks in some cases even after enabling the spectre-BTI mitigation with prctl. The kernel failed to protect applications that attempted to protect against Spectre v2 leaving them open to attack from other processes running on the same physical core in another hyperthread."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.6,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.0"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-2162.json
+++ b/csaf/vex/cve/2023/cve-2023-2162.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-2162",
+    "tracking": {
+      "id": "CVE-2023-2162",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-2162",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in iscsi_sw_tcp_session_create in drivers/scsi/iscsi_tcp.c in the SCSI sub-component in the Linux Kernel. This issue could allow an attacker to leak kernel internal information."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.6,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-23454.json
+++ b/csaf/vex/cve/2023/cve-2023-23454.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-23454",
+    "tracking": {
+      "id": "CVE-2023-23454",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-23454",
+      "notes": [
+        {
+          "category": "description",
+          "text": "An out-of-bounds (OOB) read problem was found in cbq_classify in net/sched/sch_cbq.c in the Linux kernel. This issue may allow a local attacker to cause a denial of service due to type confusion. Non-negative numbers could indicate a TC_ACT_SHOT condition rather than valid classification results."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.2,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-26545.json
+++ b/csaf/vex/cve/2023/cve-2023-26545.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-26545",
+    "tracking": {
+      "id": "CVE-2023-26545",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-26545",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A double-free flaw was found in the Linux kernel when the MPLS implementation handled sysctl allocation failures. This issue could allow a local user to cause a denial of service or possibly execute arbitrary code."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.7,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-3161.json
+++ b/csaf/vex/cve/2023/cve-2023-3161.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-3161",
+    "tracking": {
+      "id": "CVE-2023-3161",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-3161",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Framebuffer Console (fbcon) in the Linux Kernel. When providing a font->width and font->height greater than 32 to the fbcon_set_font, since there are no checks in place, a shift-out-of-bounds occurs, leading to undefined behavior and possible denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-3268.json
+++ b/csaf/vex/cve/2023/cve-2023-3268.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-3268",
+    "tracking": {
+      "id": "CVE-2023-3268",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-3268",
+      "notes": [
+        {
+          "category": "description",
+          "text": "An out-of-bounds (OOB) memory access flaw was found in the Linux kernel in relay_file_read_start_pos in kernel/relay.c in the relayfs. This flaw allows a local attacker to crash the system or leak kernel internal information."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.0,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-33203.json
+++ b/csaf/vex/cve/2023/cve-2023-33203.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-33203",
+    "tracking": {
+      "id": "CVE-2023-33203",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-33203",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A race condition vulnerability was found in the Linux kernel's Qualcomm EMAC Gigabit Ethernet Controller when the user physically removes the device before cleanup in the emac_remove function. This flaw can eventually result in a use-after-free issue, possibly leading to a system crash or other undefined behaviors."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "PHYSICAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:P/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-35823.json
+++ b/csaf/vex/cve/2023/cve-2023-35823.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-35823",
+    "tracking": {
+      "id": "CVE-2023-35823",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-35823",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A race condition was found in the Linux kernel's saa7134 device driver. This occurs when removing the module before cleanup in the saa7134_finidev function which can result in a use-after-free issue, possibly leading to a system crash or other undefined behaviors."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.7,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-35824.json
+++ b/csaf/vex/cve/2023/cve-2023-35824.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-35824",
+    "tracking": {
+      "id": "CVE-2023-35824",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-35824",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A race condition was found in the Linux kernel's dm1105 device driver when removing the module before cleanup in the dm1105_remove function. This can result in a use-after-free issue, possibly leading to a system crash or other undefined behaviors."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-3772.json
+++ b/csaf/vex/cve/2023/cve-2023-3772.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-3772",
+    "tracking": {
+      "id": "CVE-2023-3772",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-3772",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel\u2019s IP framework for transforming packets (XFRM subsystem). This issue may allow a malicious user with CAP_NET_ADMIN privileges to directly dereference a NULL pointer in xfrm_update_ae_params(), leading to a possible kernel crash and denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-38409.json
+++ b/csaf/vex/cve/2023/cve-2023-38409.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-38409",
+    "tracking": {
+      "id": "CVE-2023-38409",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-38409",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A memory corruption flaw was found in set_con2fb_map in drivers/video/fbdev/core/fbcon.c in the Framebuffer Console in the Linux kernel. This flaw allows a local attacker to crash the system, leading to a denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-4459.json
+++ b/csaf/vex/cve/2023/cve-2023-4459.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-4459",
+    "tracking": {
+      "id": "CVE-2023-4459",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-4459",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A NULL pointer dereference flaw was found in vmxnet3_rq_cleanup in drivers/net/vmxnet3/vmxnet3_drv.c in the networking sub-component in vmxnet3 in the Linux Kernel. This issue may allow a local attacker with normal user privilege to cause a denial of service due to a missing sanity check during cleanup."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-4622.json
+++ b/csaf/vex/cve/2023/cve-2023-4622.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-4622",
+    "tracking": {
+      "id": "CVE-2023-4622",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-4622",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in the Linux kernel's af_unix component that allows local privilege escalation. The unix_stream_sendpage() function tries to add data to the last skb in the peer's recv queue without locking the queue. This issue leads to a race condition where the unix_stream_sendpage() function could access a skb that is being released by garbage collection, resulting in a use-after-free issue."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.6,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-4732.json
+++ b/csaf/vex/cve/2023/cve-2023-4732.json
@@ -1,0 +1,887 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-4732",
+    "tracking": {
+      "id": "CVE-2023-4732",
+      "initial_release_date": "2025-10-24T16:20:21Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-4732",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in pfn_swap_entry_to_page in memory management subsystem in the Linux Kernel. In this flaw, an attacker with a local user privilege may cause a denial of service problem due to a BUG statement referencing pmd_t x."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.7,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-0565.json
+++ b/csaf/vex/cve/2024/cve-2024-0565.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-0565",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-10-24T16:20:21Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-10-24T16:20:21Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -81,6 +86,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
                         }
                       }
                     ]
@@ -231,6 +244,512 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686"
                         }
                       }
                     ]
@@ -1037,6 +1556,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1055,6 +1575,67 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
           "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1154,6 +1735,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1172,6 +1754,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1284,6 +1927,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1302,6 +1946,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1402,6 +2107,7 @@
           "details": "Moderate",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1420,6 +2126,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.i686",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",


### PR DESCRIPTION
These CVEs were completed prior to the CSAF project getting into full swing.  We know via release tagging in the kernel-src-tree which binaries they're associated.  We picked CSAF files if they had the same NVR (save some minor variation) to get the all the binary file names. If we had a release that does not seem to be represented in CSAF we picked the nearest one that existed and used those binary file names.