### PR TITLE
CVE-2024-4032: cbr-7.9 python known_not_affected

### DIFF
--- a/csaf/vex/cve/2024/cve-2024-4032.json
+++ b/csaf/vex/cve/2024/cve-2024-4032.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-4032",
       "initial_release_date": "2024-07-26T22:45:45Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2026-02-19T16:08:51Z",
       "status": "final",
-      "version": "7",
+      "version": "8",
       "revision_history": [
         {
           "date": "2024-07-26T22:45:45Z",
@@ -62,6 +62,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "7",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-02-19T16:08:51Z",
+          "number": "8",
           "summary": "Updated version"
         }
       ]
@@ -1290,6 +1295,26 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python",
+                        "product": {
+                          "name": "cbr-7.9:python",
+                          "product_id": "cbr-7.9:python"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1307,6 +1332,9 @@
         }
       ],
       "product_status": {
+        "known_not_affected": [
+          "cbr-7.9:python"
+        ],
         "fixed": [
           "lts-9.2:python3.11-3.11.7-1.el9_2.92ciq_lts.3.src",
           "lts-9.2:python3.11-3.11.7-1.el9_2.92ciq_lts.3.aarch64",


### PR DESCRIPTION
Python 2.7 does not include the `ipaddress` module (added in Python 3.3 stdlib), so cbr-7.9 python is not vulnerable to CVE-2024-4032.

Adds `cbr-7.9:python` to `known_not_affected` in the existing CVE-2024-4032 CSAF VEX file (version 7 → 8).