### PR TITLE
CVE fixes for LTS 8.6 kernel

### DIFF
--- a/csaf/vex/cve/2022/cve-2022-48786.json
+++ b/csaf/vex/cve/2022/cve-2022-48786.json
@@ -1,0 +1,497 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-48786",
+    "tracking": {
+      "id": "CVE-2022-48786",
+      "initial_release_date": "2026-04-03T23:02:24Z",
+      "current_release_date": "2026-04-03T23:02:24Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-03T23:02:24Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-48786",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A vulnerability was found in the Linux kernel's vsock subsystem's vsock_stream_connect() function where improper handling of the socket state can lead to the connected table's list being corrupted. This occurs when a signal interrupt occurs and resets the socket's state without removing it from the connected table; the process then attempts the connect() function again, which if successful, can lead to the socket being added a second time to the connected table, corrupting the linked list structure used for managing connected sockets. This vulnerability can potentially lead to memory corruption and system instability."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "LOW",
+            "baseScore": 4.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-58002.json
+++ b/csaf/vex/cve/2024/cve-2024-58002.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-58002",
       "initial_release_date": "2025-09-18T12:40:03Z",
-      "current_release_date": "2025-12-31T19:44:07Z",
+      "current_release_date": "2026-04-03T23:02:24Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2025-09-18T12:40:03Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-12-31T19:44:07Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:02:24Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -3012,6 +3017,272 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3380,7 +3651,38 @@
           "lts-9.2:rtla-5.14.0-284.30.1+16.1.el9_2_ciq.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1+16.1.el9_2_ciq.src",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1+16.1.el9_2_ciq.noarch",
-          "lts-9.2:kernel-doc-5.14.0-284.30.1+16.1.el9_2_ciq.noarch"
+          "lts-9.2:kernel-doc-5.14.0-284.30.1+16.1.el9_2_ciq.noarch",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -3738,7 +4040,38 @@
             "lts-9.2:rtla-5.14.0-284.30.1+16.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1+16.1.el9_2_ciq.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1+16.1.el9_2_ciq.noarch",
-            "lts-9.2:kernel-doc-5.14.0-284.30.1+16.1.el9_2_ciq.noarch"
+            "lts-9.2:kernel-doc-5.14.0-284.30.1+16.1.el9_2_ciq.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -4109,7 +4442,38 @@
             "lts-9.2:rtla-5.14.0-284.30.1+16.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1+16.1.el9_2_ciq.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1+16.1.el9_2_ciq.noarch",
-            "lts-9.2:kernel-doc-5.14.0-284.30.1+16.1.el9_2_ciq.noarch"
+            "lts-9.2:kernel-doc-5.14.0-284.30.1+16.1.el9_2_ciq.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -4468,7 +4832,38 @@
             "lts-9.2:rtla-5.14.0-284.30.1+16.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1+16.1.el9_2_ciq.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1+16.1.el9_2_ciq.noarch",
-            "lts-9.2:kernel-doc-5.14.0-284.30.1+16.1.el9_2_ciq.noarch"
+            "lts-9.2:kernel-doc-5.14.0-284.30.1+16.1.el9_2_ciq.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-22026.json
+++ b/csaf/vex/cve/2025/cve-2025-22026.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-22026",
       "initial_release_date": "2025-10-17T00:58:59Z",
-      "current_release_date": "2026-03-06T16:47:59Z",
+      "current_release_date": "2026-04-03T23:02:24Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2025-10-17T00:58:59Z",
@@ -37,6 +37,11 @@
         {
           "date": "2026-03-06T16:47:59Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:02:24Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -905,6 +910,272 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1025,7 +1296,38 @@
           "lts-9.4:kernel-doc-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.noarch",
           "lts-9.4:kernel-tools-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
           "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
-          "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64"
+          "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -1135,7 +1437,38 @@
             "lts-9.4:kernel-doc-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.noarch",
             "lts-9.4:kernel-tools-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
-            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64"
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -1258,7 +1591,38 @@
             "lts-9.4:kernel-doc-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.noarch",
             "lts-9.4:kernel-tools-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
-            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64"
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -1369,7 +1733,38 @@
             "lts-9.4:kernel-doc-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.noarch",
             "lts-9.4:kernel-tools-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
-            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64"
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1.el9_4.94ciq_lts.10.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38449.json
+++ b/csaf/vex/cve/2025/cve-2025-38449.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-38449",
       "initial_release_date": "2025-10-30T19:55:05Z",
-      "current_release_date": "2026-03-06T16:50:22Z",
+      "current_release_date": "2026-04-03T23:02:24Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2025-10-30T19:55:05Z",
@@ -42,6 +42,11 @@
         {
           "date": "2026-03-06T16:50:22Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:02:24Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -2080,6 +2085,272 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2341,7 +2612,38 @@
           "lts-9.2:kernel-64k-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
           "lts-9.2:kernel-64k-debug-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
           "lts-9.2:kernel-debug-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
-          "lts-9.2:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64"
+          "lts-9.2:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -2592,7 +2894,38 @@
             "lts-9.2:kernel-64k-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
             "lts-9.2:kernel-64k-debug-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
             "lts-9.2:kernel-debug-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
-            "lts-9.2:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64"
+            "lts-9.2:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2856,7 +3189,38 @@
             "lts-9.2:kernel-64k-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
             "lts-9.2:kernel-64k-debug-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
             "lts-9.2:kernel-debug-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
-            "lts-9.2:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64"
+            "lts-9.2:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -3108,7 +3472,38 @@
             "lts-9.2:kernel-64k-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
             "lts-9.2:kernel-64k-debug-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
             "lts-9.2:kernel-debug-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
-            "lts-9.2:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64"
+            "lts-9.2:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.92ciq_lts.13.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-40248.json
+++ b/csaf/vex/cve/2025/cve-2025-40248.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-40248",
       "initial_release_date": "2026-02-25T22:40:18Z",
-      "current_release_date": "2026-03-31T13:45:11Z",
+      "current_release_date": "2026-04-03T23:02:24Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2026-02-25T22:40:18Z",
@@ -47,6 +47,11 @@
         {
           "date": "2026-03-31T13:45:11Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:02:24Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -2759,6 +2764,272 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3099,7 +3370,38 @@
           "lts-9.2:kernel-modules-extra-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
           "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
           "lts-9.2:kernel-uki-virt-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
-          "lts-9.2:kernel-modules-partner-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64"
+          "lts-9.2:kernel-modules-partner-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -3429,7 +3731,38 @@
             "lts-9.2:kernel-modules-extra-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
-            "lts-9.2:kernel-modules-partner-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64"
+            "lts-9.2:kernel-modules-partner-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -3772,7 +4105,38 @@
             "lts-9.2:kernel-modules-extra-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
-            "lts-9.2:kernel-modules-partner-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64"
+            "lts-9.2:kernel-modules-partner-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -4103,7 +4467,38 @@
             "lts-9.2:kernel-modules-extra-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
-            "lts-9.2:kernel-modules-partner-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64"
+            "lts-9.2:kernel-modules-partner-5.14.0-284.30.1+25.1.el9_2_ciq.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-40269.json
+++ b/csaf/vex/cve/2025/cve-2025-40269.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-40269",
       "initial_release_date": "2026-02-25T22:40:18Z",
-      "current_release_date": "2026-03-03T02:17:38Z",
+      "current_release_date": "2026-04-03T23:02:24Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2026-02-25T22:40:18Z",
@@ -37,6 +37,11 @@
         {
           "date": "2026-03-03T02:17:38Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:02:24Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -1759,6 +1764,272 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1772,7 +2043,7 @@
       "notes": [
         {
           "category": "description",
-          "text": "In the Linux kernel, the following vulnerability has been resolved:\n\nALSA: usb-audio: Fix potential overflow of PCM transfer buffer\n\nThe PCM stream data in USB-audio driver is transferred over USB URB\npacket buffers, and each packet size is determined dynamically.  The\npacket sizes are limited by some factors such as wMaxPacketSize USB\ndescriptor.  OTOH, in the current code, the actually used packet sizes\nare determined only by the rate and the PPS, which may be bigger than\nthe size limit above.  This results in a buffer overflow, as reported\nby syzbot.\n\nBasically when the limit is smaller than the calculated packet size,\nit implies that something is wrong, most likely a weird USB\ndescriptor.  So the best option would be just to return an error at\nthe parameter setup time before doing any further operations.\n\nThis patch introduces such a sanity check, and returns -EINVAL when\nthe packet size is greater than maxpacksize.  The comparison with\nep->packsize[1] alone should suffice since it's always equal or\ngreater than ep->packsize[0]."
+          "text": "A flaw was found in the ALSA USB audio driver of the Linux kernel. This vulnerability, a buffer overflow, occurs when the size of the Pulse-Code Modulation (PCM) stream data packets exceeds the maximum allowed by the USB descriptor. A local attacker could exploit this by providing specially crafted USB audio device parameters, causing the PCM transfer buffer to overflow. This could lead to sensitive information disclosure and potentially result in a denial of service (DoS)."
         }
       ],
       "product_status": {
@@ -1982,7 +2253,38 @@
           "lts-9.6:kernel-debug-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
           "lts-9.6:kernel-64k-debug-devel-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
           "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
-          "lts-9.6:kernel-cross-headers-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64"
+          "lts-9.6:kernel-cross-headers-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -2195,7 +2497,38 @@
             "lts-9.6:kernel-debug-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-64k-debug-devel-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-cross-headers-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-cross-headers-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2421,7 +2754,38 @@
             "lts-9.6:kernel-debug-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-64k-debug-devel-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-cross-headers-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-cross-headers-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2635,7 +2999,38 @@
             "lts-9.6:kernel-debug-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-64k-debug-devel-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-cross-headers-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-cross-headers-5.14.0-570.60.1+5.1.el9_6_ciq.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]


### PR DESCRIPTION
## Summary

- Adds LTS 8.6 kernel package (`4.18.0-372.32.1+22.1.el8_6.86ciq_lts`) as fixed in 6 CVEs linked to KERNEL-798
- CVE-2022-48786: new VEX file created
- CVE-2024-58002, CVE-2025-22026, CVE-2025-38449, CVE-2025-40248, CVE-2025-40269: existing VEX files updated

## CVEs

- CVE-2025-40269
- CVE-2025-38449
- CVE-2024-58002
- CVE-2025-40248
- CVE-2025-22026
- CVE-2022-48786

Resolves KERNEL-798