### PR TITLE
Add aarch64 packages for LTS 8.6 kernel CVE fixes

### DIFF
--- a/csaf/vex/cve/2022/cve-2022-48786.json
+++ b/csaf/vex/cve/2022/cve-2022-48786.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2022-48786",
       "initial_release_date": "2026-04-03T23:02:24Z",
-      "current_release_date": "2026-04-03T23:02:24Z",
+      "current_release_date": "2026-04-03T23:15:35Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2026-04-03T23:02:24Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2026-04-03T23:15:35Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -310,6 +315,236 @@
                         }
                       }
                     ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -360,7 +595,35 @@
           "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -398,7 +661,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -449,7 +740,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -488,7 +807,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-58002.json
+++ b/csaf/vex/cve/2024/cve-2024-58002.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-58002",
       "initial_release_date": "2025-09-18T12:40:03Z",
-      "current_release_date": "2026-04-03T23:02:24Z",
+      "current_release_date": "2026-04-03T23:15:35Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2025-09-18T12:40:03Z",
@@ -57,6 +57,11 @@
         {
           "date": "2026-04-03T23:02:24Z",
           "number": "6",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:15:35Z",
+          "number": "7",
           "summary": "Updated version"
         }
       ]
@@ -3281,6 +3286,236 @@
                         }
                       }
                     ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -3682,7 +3917,35 @@
           "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -4071,7 +4334,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -4473,7 +4764,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -4863,7 +5182,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-22026.json
+++ b/csaf/vex/cve/2025/cve-2025-22026.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-22026",
       "initial_release_date": "2025-10-17T00:58:59Z",
-      "current_release_date": "2026-04-03T23:02:24Z",
+      "current_release_date": "2026-04-03T23:15:35Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2025-10-17T00:58:59Z",
@@ -42,6 +42,11 @@
         {
           "date": "2026-04-03T23:02:24Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:15:35Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -1174,6 +1179,236 @@
                         }
                       }
                     ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -1327,7 +1562,35 @@
           "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -1468,7 +1731,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -1622,7 +1913,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -1764,7 +2083,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38449.json
+++ b/csaf/vex/cve/2025/cve-2025-38449.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-38449",
       "initial_release_date": "2025-10-30T19:55:05Z",
-      "current_release_date": "2026-04-03T23:02:24Z",
+      "current_release_date": "2026-04-03T23:15:35Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2025-10-30T19:55:05Z",
@@ -47,6 +47,11 @@
         {
           "date": "2026-04-03T23:02:24Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:15:35Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -2349,6 +2354,236 @@
                         }
                       }
                     ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -2643,7 +2878,35 @@
           "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -2925,7 +3188,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -3220,7 +3511,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -3503,7 +3822,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-40248.json
+++ b/csaf/vex/cve/2025/cve-2025-40248.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-40248",
       "initial_release_date": "2026-02-25T22:40:18Z",
-      "current_release_date": "2026-04-03T23:02:24Z",
+      "current_release_date": "2026-04-03T23:15:35Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2026-02-25T22:40:18Z",
@@ -52,6 +52,11 @@
         {
           "date": "2026-04-03T23:02:24Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:15:35Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -3028,6 +3033,236 @@
                         }
                       }
                     ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -3401,7 +3636,35 @@
           "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -3762,7 +4025,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -4136,7 +4427,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -4498,7 +4817,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-40269.json
+++ b/csaf/vex/cve/2025/cve-2025-40269.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-40269",
       "initial_release_date": "2026-02-25T22:40:18Z",
-      "current_release_date": "2026-04-03T23:02:24Z",
+      "current_release_date": "2026-04-03T23:15:35Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2026-02-25T22:40:18Z",
@@ -42,6 +42,11 @@
         {
           "date": "2026-04-03T23:02:24Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-03T23:15:35Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -2028,6 +2033,236 @@
                         }
                       }
                     ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -2284,7 +2519,35 @@
           "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -2528,7 +2791,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -2785,7 +3076,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ],
@@ -3030,7 +3349,35 @@
             "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.x86_64",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
-            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch"
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:bpftool-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+22.1.el8_6.86ciq_lts.aarch64"
           ]
         }
       ]


### PR DESCRIPTION
Adds the aarch64 build artifacts missed from the initial PR #24.

28 aarch64 packages added to each of the 6 CVEs:
- CVE-2025-40269
- CVE-2025-38449
- CVE-2024-58002
- CVE-2025-40248
- CVE-2025-22026
- CVE-2022-48786

KERNEL-798