### PR TITLE
CVE fixes for LTS 8.6 kernel 4.18.0-372.32.1+23.1.el8_6.86ciq_lts

### DIFF
--- a/csaf/vex/cve/2022/cve-2022-49674.json
+++ b/csaf/vex/cve/2022/cve-2022-49674.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-49674",
+    "tracking": {
+      "id": "CVE-2022-49674",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-49674",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel's device mapper (dm) RAID component. This vulnerability allows an attacker to cause an out-of-bounds memory access via loading a crafted dm-raid table. This may lead to a crash."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.1,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2022/cve-2022-50865.json
+++ b/csaf/vex/cve/2022/cve-2022-50865.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-50865",
+    "tracking": {
+      "id": "CVE-2022-50865",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-50865",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel\u2019s TCP implementation in the function tcp_add_backlog(). When calculating the maximum acceptable backlog for TCP sockets, the sum of the receive buffer (sk_rcvbuf), the send buffer (sk_sndbuf), and a fixed constant may exceed the maximum value of a signed integer due to both buffer values being of type int. This can result in a signed integer overflow, potentially leading to incorrect backlog limits and unexpected TCP behavior under certain workloads."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-52448.json
+++ b/csaf/vex/cve/2023/cve-2023-52448.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-52448",
+    "tracking": {
+      "id": "CVE-2023-52448",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-52448",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A NULL pointer dereference flaw was found in the Linux kernel when accessing the rgd->rd_rgl in the gfs2_rgrp_dump() function. This issue may lead to a crash."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.7,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-52486.json
+++ b/csaf/vex/cve/2023/cve-2023-52486.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-52486",
+    "tracking": {
+      "id": "CVE-2023-52486",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-52486",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel. A frame buffer can be freed while still in use in a specific situation in drivers/gpu/drm/drm_plane.c. This issue may compromise the availability."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-52667.json
+++ b/csaf/vex/cve/2023/cve-2023-52667.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-52667",
+    "tracking": {
+      "id": "CVE-2023-52667",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-52667",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A double-free flaw was found in the Linux kernel ConnectX-4 and Connect-IB cards in the Mellanox driver. This issue could allow a local user to crash the system."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-52881.json
+++ b/csaf/vex/cve/2023/cve-2023-52881.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-52881",
+    "tracking": {
+      "id": "CVE-2023-52881",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-52881",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel. Two TCP spoofing primitives exist where an attacker can brute force the server-chosen send window by acknowledging data that was never sent, called \"ghost ACKs.\" There are side channels that also allow the attacker to leak the otherwise secret server-chosen initial sequence number (ISN). One of these side channels leverages TCP SYN cookies."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-53673.json
+++ b/csaf/vex/cve/2023/cve-2023-53673.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2023-53673",
       "initial_release_date": "2026-03-12T14:59:53Z",
-      "current_release_date": "2026-03-12T14:59:53Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2026-03-12T14:59:53Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -844,6 +849,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -857,7 +1372,7 @@
       "notes": [
         {
           "category": "description",
-          "text": "In the Linux kernel, the following vulnerability has been resolved:\n\nBluetooth: hci_event: call disconnect callback before deleting conn\n\nIn hci_cs_disconnect, we do hci_conn_del even if disconnection failed.\n\nISO, L2CAP and SCO connections refer to the hci_conn without\nhci_conn_get, so disconn_cfm must be called so they can clean up their\nconn, otherwise use-after-free occurs.\n\nISO:\n==========================================================\niso_sock_connect:880: sk 00000000eabd6557\niso_connect_cis:356: 70:1a:b8:98:ff:a2 -> 28:3d:c2:4a:7e:da\n...\niso_conn_add:140: hcon 000000001696f1fd conn 00000000b6251073\nhci_dev_put:1487: hci0 orig refcnt 17\n__iso_chan_add:214: conn 00000000b6251073\niso_sock_clear_timer:117: sock 00000000eabd6557 state 3\n...\nhci_rx_work:4085: hci0 Event packet\nhci_event_packet:7601: hci0: event 0x0f\nhci_cmd_status_evt:4346: hci0: opcode 0x0406\nhci_cs_disconnect:2760: hci0: status 0x0c\nhci_sent_cmd_data:3107: hci0 opcode 0x0406\nhci_conn_del:1151: hci0 hcon 000000001696f1fd handle 2560\nhci_conn_unlink:1102: hci0: hcon 000000001696f1fd\nhci_conn_drop:1451: hcon 00000000d8521aaf orig refcnt 2\nhci_chan_list_flush:2780: hcon 000000001696f1fd\nhci_dev_put:1487: hci0 orig refcnt 21\nhci_dev_put:1487: hci0 orig refcnt 20\nhci_req_cmd_complete:3978: opcode 0x0406 status 0x0c\n... <no iso_* activity on sk/conn> ...\niso_sock_sendmsg:1098: sock 00000000dea5e2e0, sk 00000000eabd6557\nBUG: kernel NULL pointer dereference, address: 0000000000000668\nPGD 0 P4D 0\nOops: 0000 [#1] PREEMPT SMP PTI\nHardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.2-1.fc38 04/01/2014\nRIP: 0010:iso_sock_sendmsg (net/bluetooth/iso.c:1112) bluetooth\n==========================================================\n\nL2CAP:\n==================================================================\nhci_cmd_status_evt:4359: hci0: opcode 0x0406\nhci_cs_disconnect:2760: hci0: status 0x0c\nhci_sent_cmd_data:3085: hci0 opcode 0x0406\nhci_conn_del:1151: hci0 hcon ffff88800c999000 handle 3585\nhci_conn_unlink:1102: hci0: hcon ffff88800c999000\nhci_chan_list_flush:2780: hcon ffff88800c999000\nhci_chan_del:2761: hci0 hcon ffff88800c999000 chan ffff888018ddd280\n...\nBUG: KASAN: slab-use-after-free in hci_send_acl+0x2d/0x540 [bluetooth]\nRead of size 8 at addr ffff888018ddd298 by task bluetoothd/1175\n\nCPU: 0 PID: 1175 Comm: bluetoothd Tainted: G            E      6.4.0-rc4+ #2\nHardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.16.2-1.fc38 04/01/2014\nCall Trace:\n <TASK>\n dump_stack_lvl+0x5b/0x90\n print_report+0xcf/0x670\n ? __virt_addr_valid+0xf8/0x180\n ? hci_send_acl+0x2d/0x540 [bluetooth]\n kasan_report+0xa8/0xe0\n ? hci_send_acl+0x2d/0x540 [bluetooth]\n hci_send_acl+0x2d/0x540 [bluetooth]\n ? __pfx___lock_acquire+0x10/0x10\n l2cap_chan_send+0x1fd/0x1300 [bluetooth]\n ? l2cap_sock_sendmsg+0xf2/0x170 [bluetooth]\n ? __pfx_l2cap_chan_send+0x10/0x10 [bluetooth]\n ? lock_release+0x1d5/0x3c0\n ? mark_held_locks+0x1a/0x90\n l2cap_sock_sendmsg+0x100/0x170 [bluetooth]\n sock_write_iter+0x275/0x280\n ? __pfx_sock_write_iter+0x10/0x10\n ? __pfx___lock_acquire+0x10/0x10\n do_iter_readv_writev+0x176/0x220\n ? __pfx_do_iter_readv_writev+0x10/0x10\n ? find_held_lock+0x83/0xa0\n ? selinux_file_permission+0x13e/0x210\n do_iter_write+0xda/0x340\n vfs_writev+0x1b4/0x400\n ? __pfx_vfs_writev+0x10/0x10\n ? __seccomp_filter+0x112/0x750\n ? populate_seccomp_data+0x182/0x220\n ? __fget_light+0xdf/0x100\n ? do_writev+0x19d/0x210\n do_writev+0x19d/0x210\n ? __pfx_do_writev+0x10/0x10\n ? mark_held_locks+0x1a/0x90\n do_syscall_64+0x60/0x90\n ? lockdep_hardirqs_on_prepare+0x149/0x210\n ? do_syscall_64+0x6c/0x90\n ? lockdep_hardirqs_on_prepare+0x149/0x210\n entry_SYSCALL_64_after_hwframe+0x72/0xdc\nRIP: 0033:0x7ff45cb23e64\nCode: 15 d1 1f 0d 00 f7 d8 64 89 02 48 c7 c0 ff ff ff ff eb b8 0f 1f 00 f3 0f 1e fa 80 3d 9d a7 0d 00 00 74 13 b8 14 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 54 c3 0f 1f 00 48 83 ec 28 89 54 24 1c 48 89\nRSP: 002b:00007fff21ae09b8 EFLAGS: 00000202 ORIG_RAX: 0000000000000014\nRAX: ffffffffffffffda RBX: \n---truncated---"
+          "text": "A flaw was found in the Linux kernel in which a callback is not called when a Bluetooth peripheral is disconnected. This flaw leads to a use-after-free, which an attacker could use to escalate their privileges, corrupt system memory, or otherwise cause a denial of service."
         }
       ],
       "product_status": {
@@ -957,7 +1472,67 @@
           "lts-9.2:bpftool-debuginfo-7.0.0-284.30.1+24.1.el9_2_ciq.aarch64",
           "lts-9.2:kernel-64k-debug-modules-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
           "lts-9.2:kernel-modules-extra-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
-          "lts-9.2:kernel-64k-modules-internal-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64"
+          "lts-9.2:kernel-64k-modules-internal-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -1060,7 +1635,67 @@
             "lts-9.2:bpftool-debuginfo-7.0.0-284.30.1+24.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-64k-debug-modules-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-modules-extra-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
-            "lts-9.2:kernel-64k-modules-internal-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64"
+            "lts-9.2:kernel-64k-modules-internal-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -1176,7 +1811,67 @@
             "lts-9.2:bpftool-debuginfo-7.0.0-284.30.1+24.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-64k-debug-modules-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-modules-extra-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
-            "lts-9.2:kernel-64k-modules-internal-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64"
+            "lts-9.2:kernel-64k-modules-internal-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -1280,7 +1975,67 @@
             "lts-9.2:bpftool-debuginfo-7.0.0-284.30.1+24.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-64k-debug-modules-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-modules-extra-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
-            "lts-9.2:kernel-64k-modules-internal-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64"
+            "lts-9.2:kernel-64k-modules-internal-5.14.0-284.30.1+24.1.el9_2_ciq.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-26698.json
+++ b/csaf/vex/cve/2024/cve-2024-26698.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-26698",
+    "tracking": {
+      "id": "CVE-2024-26698",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-26698",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A vulnerability was found in the hv_netvsc driver in the Linux kernel, where a race condition is present between the netvsc_probe() and netvsc_remove() functions. This race condition could lead to system hangs during network device removal."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.1,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-26735.json
+++ b/csaf/vex/cve/2024/cve-2024-26735.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-26735",
+    "tracking": {
+      "id": "CVE-2024-26735",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-26735",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in the Linux kernel\u2019s IPv6 protocol functionality. This flaw allows a local user to potentially crash the system."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-26772.json
+++ b/csaf/vex/cve/2024/cve-2024-26772.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-26772",
+    "tracking": {
+      "id": "CVE-2024-26772",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-26772",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A vulnerability was found in the ext4_mb_find_by_goal() function in the Linux kernel. This issue could lead to memory corruption or crashes due to the allocation of blocks from a group with a corrupted block bitmap."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-26773.json
+++ b/csaf/vex/cve/2024/cve-2024-26773.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-26773",
+    "tracking": {
+      "id": "CVE-2024-26773",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-26773",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A vulnerability was found in the ext4_mb_try_best_found() function in the Linux kernel. This issue could lead to memory corruption or crashes due to the allocation of blocks from a group with a corrupted block bitmap."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-26801.json
+++ b/csaf/vex/cve/2024/cve-2024-26801.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-26801",
+    "tracking": {
+      "id": "CVE-2024-26801",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-26801",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in the Linux kernel\u2019s Bluetooth subsystem in how it handles hardware failure when it occurs. This flaw allows a local user to potentially crash the system."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-26826.json
+++ b/csaf/vex/cve/2024/cve-2024-26826.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-26826",
+    "tracking": {
+      "id": "CVE-2024-26826",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-26826",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel. A logical error in the Multipath TCP packet manager causes some packets intended for retransmission to be lost, resulting in a potential denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-26870.json
+++ b/csaf/vex/cve/2024/cve-2024-26870.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-26870",
+    "tracking": {
+      "id": "CVE-2024-26870",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-26870",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel. A system error can be reliably replicated with specific filesystem settings, allowing an attacker to cause a denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-35845.json
+++ b/csaf/vex/cve/2024/cve-2024-35845.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-35845",
+    "tracking": {
+      "id": "CVE-2024-35845",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-35845",
+      "notes": [
+        {
+          "category": "description",
+          "text": "In the Linux kernel, the following vulnerability has been resolved:\n\nwifi: iwlwifi: dbg-tlv: ensure NUL termination\n\nThe Linux kernel CVE team has assigned CVE-2024-35845 to this issue.\n\nUpstream advisory:\nhttps://lore.kernel.org/linux-cve-announce/2024051718-CVE-2024-35845-65bd@gregkh/T"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2025/cve-2025-22058.json
+++ b/csaf/vex/cve/2025/cve-2025-22058.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-22058",
       "initial_release_date": "2025-10-15T21:13:58Z",
-      "current_release_date": "2026-03-06T16:48:04Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2025-10-15T21:13:58Z",
@@ -42,6 +42,11 @@
         {
           "date": "2026-03-06T16:48:04Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -1636,6 +1641,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1843,7 +2358,67 @@
           "lts-9.2:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.x86_64",
           "lts-9.2:kernel-tools-libs-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.x86_64",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch",
-          "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch"
+          "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -2040,7 +2615,67 @@
             "lts-9.2:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.x86_64",
             "lts-9.2:kernel-tools-libs-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.x86_64",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch",
-            "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch"
+            "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2250,7 +2885,67 @@
             "lts-9.2:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.x86_64",
             "lts-9.2:kernel-tools-libs-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.x86_64",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch",
-            "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch"
+            "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2448,7 +3143,67 @@
             "lts-9.2:kernel-tools-libs-devel-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.x86_64",
             "lts-9.2:kernel-tools-libs-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.x86_64",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch",
-            "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch"
+            "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.12.1.noarch",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38024.json
+++ b/csaf/vex/cve/2025/cve-2025-38024.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-38024",
       "initial_release_date": "2026-03-26T04:56:26Z",
-      "current_release_date": "2026-03-31T13:53:57Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2026-03-26T04:56:26Z",
@@ -37,6 +37,11 @@
         {
           "date": "2026-03-31T13:53:57Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -1759,6 +1764,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1982,7 +2497,67 @@
           "lts-9.6:kernel-debug-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
           "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
           "lts-9.6:kernel-selftests-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
-          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64"
+          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -2195,7 +2770,67 @@
             "lts-9.6:kernel-debug-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:kernel-selftests-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2421,7 +3056,67 @@
             "lts-9.6:kernel-debug-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:kernel-selftests-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2635,7 +3330,67 @@
             "lts-9.6:kernel-debug-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:kernel-selftests-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38180.json
+++ b/csaf/vex/cve/2025/cve-2025-38180.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2025-38180",
+    "tracking": {
+      "id": "CVE-2025-38180",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2025-38180",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the Linux kernel's Asynchronous Transfer Mode (ATM) subsystem. An authenticated local attacker could exploit a Use-After-Free (UAF) vulnerability in the /proc/net/atm/lec handling. This flaw occurs due to improper dev_put() calls without prior dev_hold() calls, leading to an imbalance in reference counting. Successful exploitation could allow the attacker to achieve privilege escalation or cause a denial of service."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2025/cve-2025-38323.json
+++ b/csaf/vex/cve/2025/cve-2025-38323.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2025-38323",
+    "tracking": {
+      "id": "CVE-2025-38323",
+      "initial_release_date": "2026-04-21T02:28:00Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2025-38323",
+      "notes": [
+        {
+          "category": "description",
+          "text": "In the Linux kernel, the following vulnerability has been resolved:\n\nnet: atm: add lec_mutex\n\nsyzbot found its way in net/atm/lec.c, and found an error path\nin lecd_attach() could leave a dangling pointer in dev_lec[].\n\nAdd a mutex to protect dev_lecp[] uses from lecd_attach(),\nlec_vcc_attach() and lec_mcast_attach().\n\nFollowing patch will use this mutex for /proc/net/atm/lec.\n\nBUG: KASAN: slab-use-after-free in lecd_attach net/atm/lec.c:751 [inline]\nBUG: KASAN: slab-use-after-free in lane_ioctl+0x2224/0x23e0 net/atm/lec.c:1008\nRead of size 8 at addr ffff88807c7b8e68 by task syz.1.17/6142\n\nCPU: 1 UID: 0 PID: 6142 Comm: syz.1.17 Not tainted 6.16.0-rc1-syzkaller-00239-g08215f5486ec #0 PREEMPT(full)\nHardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 05/07/2025\nCall Trace:\n <TASK>\n  __dump_stack lib/dump_stack.c:94 [inline]\n  dump_stack_lvl+0x116/0x1f0 lib/dump_stack.c:120\n  print_address_description mm/kasan/report.c:408 [inline]\n  print_report+0xcd/0x680 mm/kasan/report.c:521\n  kasan_report+0xe0/0x110 mm/kasan/report.c:634\n  lecd_attach net/atm/lec.c:751 [inline]\n  lane_ioctl+0x2224/0x23e0 net/atm/lec.c:1008\n  do_vcc_ioctl+0x12c/0x930 net/atm/ioctl.c:159\n  sock_do_ioctl+0x118/0x280 net/socket.c:1190\n  sock_ioctl+0x227/0x6b0 net/socket.c:1311\n  vfs_ioctl fs/ioctl.c:51 [inline]\n  __do_sys_ioctl fs/ioctl.c:907 [inline]\n  __se_sys_ioctl fs/ioctl.c:893 [inline]\n  __x64_sys_ioctl+0x18e/0x210 fs/ioctl.c:893\n  do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]\n  do_syscall_64+0xcd/0x4c0 arch/x86/entry/syscall_64.c:94\n entry_SYSCALL_64_after_hwframe+0x77/0x7f\n </TASK>\n\nAllocated by task 6132:\n  kasan_save_stack+0x33/0x60 mm/kasan/common.c:47\n  kasan_save_track+0x14/0x30 mm/kasan/common.c:68\n  poison_kmalloc_redzone mm/kasan/common.c:377 [inline]\n  __kasan_kmalloc+0xaa/0xb0 mm/kasan/common.c:394\n  kasan_kmalloc include/linux/kasan.h:260 [inline]\n  __do_kmalloc_node mm/slub.c:4328 [inline]\n  __kvmalloc_node_noprof+0x27b/0x620 mm/slub.c:5015\n  alloc_netdev_mqs+0xd2/0x1570 net/core/dev.c:11711\n  lecd_attach net/atm/lec.c:737 [inline]\n  lane_ioctl+0x17db/0x23e0 net/atm/lec.c:1008\n  do_vcc_ioctl+0x12c/0x930 net/atm/ioctl.c:159\n  sock_do_ioctl+0x118/0x280 net/socket.c:1190\n  sock_ioctl+0x227/0x6b0 net/socket.c:1311\n  vfs_ioctl fs/ioctl.c:51 [inline]\n  __do_sys_ioctl fs/ioctl.c:907 [inline]\n  __se_sys_ioctl fs/ioctl.c:893 [inline]\n  __x64_sys_ioctl+0x18e/0x210 fs/ioctl.c:893\n  do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]\n  do_syscall_64+0xcd/0x4c0 arch/x86/entry/syscall_64.c:94\n entry_SYSCALL_64_after_hwframe+0x77/0x7f\n\nFreed by task 6132:\n  kasan_save_stack+0x33/0x60 mm/kasan/common.c:47\n  kasan_save_track+0x14/0x30 mm/kasan/common.c:68\n  kasan_save_free_info+0x3b/0x60 mm/kasan/generic.c:576\n  poison_slab_object mm/kasan/common.c:247 [inline]\n  __kasan_slab_free+0x51/0x70 mm/kasan/common.c:264\n  kasan_slab_free include/linux/kasan.h:233 [inline]\n  slab_free_hook mm/slub.c:2381 [inline]\n  slab_free mm/slub.c:4643 [inline]\n  kfree+0x2b4/0x4d0 mm/slub.c:4842\n  free_netdev+0x6c5/0x910 net/core/dev.c:11892\n  lecd_attach net/atm/lec.c:744 [inline]\n  lane_ioctl+0x1ce8/0x23e0 net/atm/lec.c:1008\n  do_vcc_ioctl+0x12c/0x930 net/atm/ioctl.c:159\n  sock_do_ioctl+0x118/0x280 net/socket.c:1190\n  sock_ioctl+0x227/0x6b0 net/socket.c:1311\n  vfs_ioctl fs/ioctl.c:51 [inline]\n  __do_sys_ioctl fs/ioctl.c:907 [inline]\n  __se_sys_ioctl fs/ioctl.c:893 [inline]\n  __x64_sys_ioctl+0x18e/0x210 fs/ioctl.c:893"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2025/cve-2025-39973.json
+++ b/csaf/vex/cve/2025/cve-2025-39973.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-39973",
       "initial_release_date": "2026-03-03T02:17:38Z",
-      "current_release_date": "2026-03-26T04:56:26Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2026-03-03T02:17:38Z",
@@ -37,6 +37,11 @@
         {
           "date": "2026-03-26T04:56:26Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -1759,6 +1764,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1982,7 +2497,67 @@
           "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
           "lts-9.4:kernel-64k-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
           "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
-          "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64"
+          "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -2195,7 +2770,67 @@
             "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
-            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64"
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2421,7 +3056,67 @@
             "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
-            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64"
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2635,7 +3330,67 @@
             "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
-            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64"
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-40240.json
+++ b/csaf/vex/cve/2025/cve-2025-40240.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-40240",
       "initial_release_date": "2026-03-31T13:53:57Z",
-      "current_release_date": "2026-04-17T20:55:42Z",
+      "current_release_date": "2026-04-21T02:36:31Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2026-03-31T13:53:57Z",
@@ -37,6 +37,11 @@
         {
           "date": "2026-04-17T20:55:42Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-21T02:36:31Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -1759,6 +1764,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1982,7 +2497,67 @@
           "lts-9.4:rv-5.14.0-427.42.1+17.1.el9_4_ciq.x86_64",
           "lts-9.4:kernel-5.14.0-427.42.1+17.1.el9_4_ciq.src",
           "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+17.1.el9_4_ciq.noarch",
-          "lts-9.4:kernel-doc-5.14.0-427.42.1+17.1.el9_4_ciq.noarch"
+          "lts-9.4:kernel-doc-5.14.0-427.42.1+17.1.el9_4_ciq.noarch",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -2195,7 +2770,67 @@
             "lts-9.4:rv-5.14.0-427.42.1+17.1.el9_4_ciq.x86_64",
             "lts-9.4:kernel-5.14.0-427.42.1+17.1.el9_4_ciq.src",
             "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+17.1.el9_4_ciq.noarch",
-            "lts-9.4:kernel-doc-5.14.0-427.42.1+17.1.el9_4_ciq.noarch"
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+17.1.el9_4_ciq.noarch",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2421,7 +3056,67 @@
             "lts-9.4:rv-5.14.0-427.42.1+17.1.el9_4_ciq.x86_64",
             "lts-9.4:kernel-5.14.0-427.42.1+17.1.el9_4_ciq.src",
             "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+17.1.el9_4_ciq.noarch",
-            "lts-9.4:kernel-doc-5.14.0-427.42.1+17.1.el9_4_ciq.noarch"
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+17.1.el9_4_ciq.noarch",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2635,7 +3330,67 @@
             "lts-9.4:rv-5.14.0-427.42.1+17.1.el9_4_ciq.x86_64",
             "lts-9.4:kernel-5.14.0-427.42.1+17.1.el9_4_ciq.src",
             "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+17.1.el9_4_ciq.noarch",
-            "lts-9.4:kernel-doc-5.14.0-427.42.1+17.1.el9_4_ciq.noarch"
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+17.1.el9_4_ciq.noarch",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-71085.json
+++ b/csaf/vex/cve/2025/cve-2025-71085.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-71085",
       "initial_release_date": "2026-03-26T04:56:26Z",
-      "current_release_date": "2026-03-31T13:53:57Z",
+      "current_release_date": "2026-04-21T02:28:00Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2026-03-26T04:56:26Z",
@@ -37,6 +37,11 @@
         {
           "date": "2026-03-31T13:53:57Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-04-21T02:28:00Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -1759,6 +1764,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1982,7 +2497,67 @@
           "lts-9.6:kernel-debug-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
           "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
           "lts-9.6:kernel-selftests-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
-          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64"
+          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
         ]
       },
       "remediations": [
@@ -2195,7 +2770,67 @@
             "lts-9.6:kernel-debug-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:kernel-selftests-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2421,7 +3056,67 @@
             "lts-9.6:kernel-debug-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:kernel-selftests-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ],
@@ -2635,7 +3330,67 @@
             "lts-9.6:kernel-debug-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:libperf-debuginfo-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
             "lts-9.6:kernel-selftests-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+6.1.el9_6_ciq.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.src",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1+23.1.el8_6.86ciq_lts.noarch"
           ]
         }
       ]


### PR DESCRIPTION
## Summary

- Publish VEX files for 22 CVEs fixed in kernel `4.18.0-372.32.1+23.1.el8_6.86ciq_lts` (LTS 8.6)
- Covers both x86_64 and aarch64 packages (60 RPMs per CVE)
- 16 new VEX files created; 6 existing files updated with new packages

> **Note:** This PR is rebased on #26 — merge #26 first.

## CVEs

- CVE-2023-53673
- CVE-2022-50865
- CVE-2025-22058
- CVE-2025-39973
- CVE-2023-52486
- CVE-2025-38024
- CVE-2025-40240
- CVE-2023-52448
- CVE-2024-26773
- CVE-2025-38323
- CVE-2024-26772
- CVE-2023-52881
- CVE-2025-71085
- CVE-2023-52667
- CVE-2025-38180
- CVE-2024-26698
- CVE-2024-35845
- CVE-2024-26826
- CVE-2024-26735
- CVE-2022-49674
- CVE-2024-26801
- CVE-2024-26870

Closes KERNEL-851

🤖 Generated with [Claude Code](https://claude.com/claude-code)