### PR TITLE
CVE fixes for KERNEL-901

### DIFF
--- a/csaf/vex/cve/2026/cve-2026-23060.json
+++ b/csaf/vex/cve/2026/cve-2026-23060.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2026-23060",
       "initial_release_date": "2026-05-01T04:03:06Z",
-      "current_release_date": "2026-05-01T04:03:06Z",
+      "current_release_date": "2026-05-01T13:49:56Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2026-05-01T04:03:06Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2026-05-01T13:49:56Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -892,6 +897,868 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.4",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                        "product": {
+                          "name": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                          "product_id": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                        "product": {
+                          "name": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                          "product_id": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1011,7 +1878,111 @@
           "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
           "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
           "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+          "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+          "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+          "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
         ]
       },
       "remediations": [
@@ -1120,7 +2091,111 @@
             "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
           ]
         }
       ],
@@ -1242,7 +2317,111 @@
             "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
           ]
         }
       ],
@@ -1352,7 +2531,111 @@
             "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
           ]
         }
       ]

--- a/csaf/vex/cve/2026/cve-2026-31431.json
+++ b/csaf/vex/cve/2026/cve-2026-31431.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2026-31431",
       "initial_release_date": "2026-05-01T04:03:06Z",
-      "current_release_date": "2026-05-01T04:03:06Z",
+      "current_release_date": "2026-05-01T13:49:56Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2026-05-01T04:03:06Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2026-05-01T13:49:56Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -892,6 +897,868 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.4",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                        "product": {
+                          "name": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                          "product_id": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                        "product": {
+                          "name": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                          "product_id": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1011,7 +1878,111 @@
           "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
           "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
           "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+          "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+          "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+          "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
         ]
       },
       "remediations": [
@@ -1120,7 +2091,111 @@
             "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
           ]
         }
       ],
@@ -1242,7 +2317,111 @@
             "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
           ]
         }
       ],
@@ -1352,7 +2531,111 @@
             "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
           ]
         }
       ]

--- a/csaf/vex/cve/2026/cve-2026-31677.json
+++ b/csaf/vex/cve/2026/cve-2026-31677.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2026-31677",
       "initial_release_date": "2026-05-01T04:03:06Z",
-      "current_release_date": "2026-05-01T04:03:06Z",
+      "current_release_date": "2026-05-01T13:49:56Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2026-05-01T04:03:06Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2026-05-01T13:49:56Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -892,6 +897,868 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.4",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                        "product": {
+                          "name": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                          "product_id": "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                        "product": {
+                          "name": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+                          "product_id": "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                        "product": {
+                          "name": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+                          "product_id": "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                        "product": {
+                          "name": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+                          "product_id": "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src",
+                        "product": {
+                          "name": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src",
+                          "product_id": "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1011,7 +1878,111 @@
           "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
           "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
           "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+          "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+          "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+          "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+          "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+          "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+          "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
         ]
       },
       "remediations": [
@@ -1120,7 +2091,111 @@
             "lts-9.6:libperf-devel-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debuginfo-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
             "lts-9.6:kernel-debug-modules-partner-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
-            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64"
+            "lts-9.6:kernel-debug-modules-internal-5.14.0-570.60.1+8.1.el9_6_ciq.aarch64",
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+19.1.el9_4_ciq.noarch",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-common-aarch64-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-64k-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.aarch64",
+            "lts-9.4:kernel-tools-libs-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-libs-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-debuginfo-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:bpftool-7.3.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rv-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-ipaclones-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-common-x86_64-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-cross-headers-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-extra-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-matched-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:libperf-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-devel-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-modules-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-partner-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:perf-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debuginfo-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:rtla-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:python3-perf-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-modules-core-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-debug-uki-virt-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-tools-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-selftests-internal-5.14.0-427.42.1+19.1.el9_4_ciq.x86_64",
+            "lts-9.4:kernel-5.14.0-427.42.1+19.1.el9_4_ciq.src"
           ]
         }
       ]


### PR DESCRIPTION
Fixup of: https://github.com/ctrliq/advisories/pull/33

CVE-2026-31677
CVE-2026-23060
CVE-2026-31431

KERNEL-901