### PR TITLE
CVE fixes for KERNEL-960

### DIFF
--- a/csaf/vex/cve/2023/cve-2023-53675.json
+++ b/csaf/vex/cve/2023/cve-2023-53675.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-53675",
       "initial_release_date": "2026-02-04T13:55:54Z",
-      "current_release_date": "2026-02-20T14:41:15Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2026-02-04T13:55:54Z",
@@ -42,6 +42,11 @@
         {
           "date": "2026-02-20T14:41:15Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -1652,6 +1657,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1665,7 +1862,7 @@
       "notes": [
         {
           "category": "description",
-          "text": "In the Linux kernel, the following vulnerability has been resolved:\n\nscsi: ses: Fix possible desc_ptr out-of-bounds accesses\n\nSanitize possible desc_ptr out-of-bounds accesses in\nses_enclosure_data_process()."
+          "text": "A bounds-checking flaw was found in the Linux kernel Small Computer System Interface Enclosure Services driver in the way descriptor pointers are validated while processing enclosure data. Missing checks could allow an out-of-bounds access during parsing. \nA local user could use this flaw to crash the system while enclosure data is processed, resulting in a denial of service."
         }
       ],
       "product_status": {
@@ -1858,7 +2055,28 @@
           "lts-9.2:kernel-debug-modules-extra-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
           "lts-9.2:kernel-debug-modules-partner-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
           "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
-          "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64"
+          "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -2054,7 +2272,28 @@
             "lts-9.2:kernel-debug-modules-extra-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-debug-modules-partner-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
-            "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64"
+            "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -2263,7 +2502,28 @@
             "lts-9.2:kernel-debug-modules-extra-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-debug-modules-partner-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
-            "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64"
+            "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -2460,7 +2720,28 @@
             "lts-9.2:kernel-debug-modules-extra-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-debug-modules-partner-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
-            "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64"
+            "lts-9.2:kernel-64k-debuginfo-5.14.0-284.30.1+23.1.el9_2_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38024.json
+++ b/csaf/vex/cve/2025/cve-2025-38024.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-38024",
       "initial_release_date": "2026-03-26T04:56:26Z",
-      "current_release_date": "2026-04-22T17:01:03Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2026-03-26T04:56:26Z",
@@ -42,6 +42,11 @@
         {
           "date": "2026-04-22T17:01:03Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -2274,6 +2279,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2557,7 +2754,28 @@
           "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
           "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
           "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
-          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64"
+          "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -2830,7 +3048,28 @@
             "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
             "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
             "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
-            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64"
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -3116,7 +3355,28 @@
             "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
             "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
             "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
-            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64"
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -3390,7 +3650,28 @@
             "lts-8.6:kernel-tools-libs-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
             "lts-8.6:kernel-cross-headers-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
             "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
-            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64"
+            "lts-8.6:bpftool-4.18.0-372.32.1+23.1.el8_6_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38180.json
+++ b/csaf/vex/cve/2025/cve-2025-38180.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-38180",
       "initial_release_date": "2026-04-22T17:01:03Z",
-      "current_release_date": "2026-04-29T22:33:21Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2026-04-22T17:01:03Z",
@@ -47,6 +47,11 @@
         {
           "date": "2026-04-29T22:33:21Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -3077,6 +3082,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3456,7 +3653,28 @@
           "lts-9.4:python3-perf-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
           "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
           "lts-9.4:rtla-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
-          "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64"
+          "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -3825,7 +4043,28 @@
             "lts-9.4:python3-perf-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:rtla-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
-            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64"
+            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4207,7 +4446,28 @@
             "lts-9.4:python3-perf-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:rtla-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
-            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64"
+            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4577,7 +4837,28 @@
             "lts-9.4:python3-perf-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:rtla-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
-            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64"
+            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38323.json
+++ b/csaf/vex/cve/2025/cve-2025-38323.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-38323",
       "initial_release_date": "2026-04-22T17:01:03Z",
-      "current_release_date": "2026-04-29T22:33:21Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2026-04-22T17:01:03Z",
@@ -47,6 +47,11 @@
         {
           "date": "2026-04-29T22:33:21Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -3077,6 +3082,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3456,7 +3653,28 @@
           "lts-9.4:python3-perf-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
           "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
           "lts-9.4:rtla-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
-          "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64"
+          "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -3825,7 +4043,28 @@
             "lts-9.4:python3-perf-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:rtla-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
-            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64"
+            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4207,7 +4446,28 @@
             "lts-9.4:python3-perf-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:rtla-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
-            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64"
+            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4577,7 +4837,28 @@
             "lts-9.4:python3-perf-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:python3-perf-debuginfo-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
             "lts-9.4:rtla-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
-            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64"
+            "lts-9.4:rv-5.14.0-427.42.1+18.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38415.json
+++ b/csaf/vex/cve/2025/cve-2025-38415.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-38415",
       "initial_release_date": "2026-03-18T02:03:34Z",
-      "current_release_date": "2026-03-26T04:56:26Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2026-03-18T02:03:34Z",
@@ -37,6 +37,11 @@
         {
           "date": "2026-03-26T04:56:26Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -1431,6 +1436,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1613,7 +1810,28 @@
           "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
           "lts-9.4:kernel-64k-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
           "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
-          "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64"
+          "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -1785,7 +2003,28 @@
             "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
-            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64"
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -1970,7 +2209,28 @@
             "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
-            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64"
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -2143,7 +2403,28 @@
             "lts-9.4:kernel-64k-debug-modules-core-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
             "lts-9.4:kernel-64k-debug-modules-extra-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
-            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64"
+            "lts-9.4:kernel-debug-5.14.0-427.42.1+16.1.el9_4_ciq.aarch64",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-38459.json
+++ b/csaf/vex/cve/2025/cve-2025-38459.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2025-38459",
       "initial_release_date": "2026-03-18T02:03:34Z",
-      "current_release_date": "2026-03-18T02:03:34Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2026-03-18T02:03:34Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -564,6 +569,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -642,7 +839,28 @@
           "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
           "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
           "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-          "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+          "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -710,7 +928,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -791,7 +1030,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -860,7 +1120,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-39817.json
+++ b/csaf/vex/cve/2025/cve-2025-39817.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-39817",
       "initial_release_date": "2025-11-07T06:53:55Z",
-      "current_release_date": "2026-03-18T02:03:34Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2025-11-07T06:53:55Z",
@@ -57,6 +57,11 @@
         {
           "date": "2026-03-18T02:03:34Z",
           "number": "6",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "7",
           "summary": "Updated version"
         }
       ]
@@ -3513,6 +3518,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3940,7 +4137,28 @@
           "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
           "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
           "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-          "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+          "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -4357,7 +4575,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4787,7 +5026,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -5205,7 +5465,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2025/cve-2025-68349.json
+++ b/csaf/vex/cve/2025/cve-2025-68349.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2025-68349",
       "initial_release_date": "2026-02-25T22:40:18Z",
-      "current_release_date": "2026-03-18T02:03:34Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2026-02-25T22:40:18Z",
@@ -42,6 +42,11 @@
         {
           "date": "2026-03-18T02:03:34Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -2282,6 +2287,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2566,7 +2763,28 @@
           "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
           "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
           "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-          "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+          "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -2840,7 +3058,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -3127,7 +3366,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -3402,7 +3662,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2026/cve-2026-23074.json
+++ b/csaf/vex/cve/2026/cve-2026-23074.json
@@ -25,14 +25,19 @@
     "tracking": {
       "id": "CVE-2026-23074",
       "initial_release_date": "2026-03-18T02:03:34Z",
-      "current_release_date": "2026-03-18T02:03:34Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2026-03-18T02:03:34Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -564,6 +569,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -642,7 +839,28 @@
           "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
           "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
           "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-          "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+          "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -710,7 +928,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -791,7 +1030,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -860,7 +1120,28 @@
             "lts-8.6:bpftool-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
             "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1+21.1.el8_6.86ciq_lts.aarch64",
-            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src"
+            "lts-8.6:kernel-4.18.0-372.32.1+21.1.el8_6_ciq.src",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2026/cve-2026-23193.json
+++ b/csaf/vex/cve/2026/cve-2026-23193.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2026-23193",
       "initial_release_date": "2026-04-27T20:27:01Z",
-      "current_release_date": "2026-05-09T02:54:56Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2026-04-27T20:27:01Z",
@@ -47,6 +47,11 @@
         {
           "date": "2026-05-09T02:54:56Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -3077,6 +3082,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3456,7 +3653,28 @@
           "lts-9.2:rtla-5.14.0-284.30.1+28.1.el9_2_ciq.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1+28.1.el9_2_ciq.src",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1+28.1.el9_2_ciq.noarch",
-          "lts-9.2:kernel-doc-5.14.0-284.30.1+28.1.el9_2_ciq.noarch"
+          "lts-9.2:kernel-doc-5.14.0-284.30.1+28.1.el9_2_ciq.noarch",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -3825,7 +4043,28 @@
             "lts-9.2:rtla-5.14.0-284.30.1+28.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1+28.1.el9_2_ciq.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1+28.1.el9_2_ciq.noarch",
-            "lts-9.2:kernel-doc-5.14.0-284.30.1+28.1.el9_2_ciq.noarch"
+            "lts-9.2:kernel-doc-5.14.0-284.30.1+28.1.el9_2_ciq.noarch",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4207,7 +4446,28 @@
             "lts-9.2:rtla-5.14.0-284.30.1+28.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1+28.1.el9_2_ciq.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1+28.1.el9_2_ciq.noarch",
-            "lts-9.2:kernel-doc-5.14.0-284.30.1+28.1.el9_2_ciq.noarch"
+            "lts-9.2:kernel-doc-5.14.0-284.30.1+28.1.el9_2_ciq.noarch",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4577,7 +4837,28 @@
             "lts-9.2:rtla-5.14.0-284.30.1+28.1.el9_2_ciq.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1+28.1.el9_2_ciq.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1+28.1.el9_2_ciq.noarch",
-            "lts-9.2:kernel-doc-5.14.0-284.30.1+28.1.el9_2_ciq.noarch"
+            "lts-9.2:kernel-doc-5.14.0-284.30.1+28.1.el9_2_ciq.noarch",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2026/cve-2026-23204.json
+++ b/csaf/vex/cve/2026/cve-2026-23204.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2026-23204",
       "initial_release_date": "2026-04-27T20:27:01Z",
-      "current_release_date": "2026-05-09T01:30:22Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2026-04-27T20:27:01Z",
@@ -47,6 +47,11 @@
         {
           "date": "2026-05-09T01:30:22Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -3077,6 +3082,198 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3456,7 +3653,28 @@
           "lts-9.4:rv-5.14.0-427.42.1+20.1.el9_4_ciq.x86_64",
           "lts-9.4:kernel-5.14.0-427.42.1+20.1.el9_4_ciq.src",
           "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+20.1.el9_4_ciq.noarch",
-          "lts-9.4:kernel-doc-5.14.0-427.42.1+20.1.el9_4_ciq.noarch"
+          "lts-9.4:kernel-doc-5.14.0-427.42.1+20.1.el9_4_ciq.noarch",
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
         ]
       },
       "remediations": [
@@ -3825,7 +4043,28 @@
             "lts-9.4:rv-5.14.0-427.42.1+20.1.el9_4_ciq.x86_64",
             "lts-9.4:kernel-5.14.0-427.42.1+20.1.el9_4_ciq.src",
             "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+20.1.el9_4_ciq.noarch",
-            "lts-9.4:kernel-doc-5.14.0-427.42.1+20.1.el9_4_ciq.noarch"
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+20.1.el9_4_ciq.noarch",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4207,7 +4446,28 @@
             "lts-9.4:rv-5.14.0-427.42.1+20.1.el9_4_ciq.x86_64",
             "lts-9.4:kernel-5.14.0-427.42.1+20.1.el9_4_ciq.src",
             "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+20.1.el9_4_ciq.noarch",
-            "lts-9.4:kernel-doc-5.14.0-427.42.1+20.1.el9_4_ciq.noarch"
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+20.1.el9_4_ciq.noarch",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ],
@@ -4577,7 +4837,28 @@
             "lts-9.4:rv-5.14.0-427.42.1+20.1.el9_4_ciq.x86_64",
             "lts-9.4:kernel-5.14.0-427.42.1+20.1.el9_4_ciq.src",
             "lts-9.4:kernel-abi-stablelists-5.14.0-427.42.1+20.1.el9_4_ciq.noarch",
-            "lts-9.4:kernel-doc-5.14.0-427.42.1+20.1.el9_4_ciq.noarch"
+            "lts-9.4:kernel-doc-5.14.0-427.42.1+20.1.el9_4_ciq.noarch",
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
           ]
         }
       ]

--- a/csaf/vex/cve/2026/cve-2026-23216.json
+++ b/csaf/vex/cve/2026/cve-2026-23216.json
@@ -1,0 +1,383 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2026-23216",
+    "tracking": {
+      "id": "CVE-2026-23216",
+      "initial_release_date": "2026-05-13T17:44:23Z",
+      "current_release_date": "2026-05-13T17:44:23Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2026-05-13T17:44:23Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                        "product": {
+                          "name": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+                          "product_id": "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                        "product": {
+                          "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+                          "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                        "product": {
+                          "name": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+                          "product_id": "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2026-23216",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in the Linux kernel's iSCSI target subsystem. In the iscsit_dec_conn_usage_count() function, complete() is called while still holding the conn->conn_usage_lock spinlock. The waiting thread (such as iscsit_close_connection()) may wake up immediately and free the iscsit_conn structure before the current thread executes spin_unlock_bh(), resulting in a use-after-free when attempting to release the lock on already-freed memory."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+          "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+          "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+          "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from your CIQ repository.",
+          "product_ids": [
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.0,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "cbr-7.9:bpftool-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:bpftool-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debug-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-tools-libs-devel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:python-perf-debuginfo-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.x86_64",
+            "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.src",
+            "cbr-7.9:kernel-abi-whitelists-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch",
+            "cbr-7.9:kernel-doc-3.10.0-1160.119.1.el7_9.ciqcbr.15.1.noarch"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
CVE-2025-38180
CVE-2025-38323
CVE-2025-38415
CVE-2025-38459
CVE-2025-39817
CVE-2023-53675
CVE-2025-38024
CVE-2025-68349
CVE-2026-23074
CVE-2026-23204
CVE-2026-23193
CVE-2026-23216

KERNEL-960